### PR TITLE
[feat/#15] feat: 프로젝트 내 서비스 별 상태 조회 기능 추가

### DIFF
--- a/src/main/java/codesquad/bows/global/config/KubeClientConfig.java
+++ b/src/main/java/codesquad/bows/global/config/KubeClientConfig.java
@@ -1,6 +1,7 @@
 package codesquad.bows.global.config;
 
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.KubeConfig;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,5 +25,10 @@ public class KubeClientConfig {
                 .build();
         io.kubernetes.client.openapi.Configuration.setDefaultApiClient(client);
         return client;
+    }
+
+    @Bean
+    public CoreV1Api coreV1Api(ApiClient apiClient) {
+        return new CoreV1Api(apiClient);
     }
 }

--- a/src/main/java/codesquad/bows/project/dto/ServiceMetadata.java
+++ b/src/main/java/codesquad/bows/project/dto/ServiceMetadata.java
@@ -1,21 +1,22 @@
 package codesquad.bows.project.dto;
 
-import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServicePort;
 
 import java.util.List;
 
-public record ServicePodMetadata(
+public record ServiceMetadata(
         String serviceName,
         List<String> externalIps,
         List<Integer> ports,
         String age,
         String imageName,
-        String
+        String state,
+        String stateReason,
+        String stateMessage
 ) {
 
-    public static ServicePodMetadata of(V1Service service, V1ContainerStatus containerStatus) {
+    public static ServiceMetadata of(V1Service service, ServiceState serviceState) {
 
         String name = service.getMetadata().getName();
         List<String> externalIPs = service.getSpec().getExternalIPs();
@@ -25,6 +26,7 @@ public record ServicePodMetadata(
                 .toList();
         String creationTimestamp = service.getMetadata().getCreationTimestamp().toString();
 
-        return new ServicePodMetadata(name, externalIPs, ports, creationTimestamp);
+        return new ServiceMetadata(name, externalIPs, ports, creationTimestamp,
+                serviceState.imageName(), serviceState.state(), serviceState.reason(), serviceState.message());
     }
 }

--- a/src/main/java/codesquad/bows/project/dto/ServiceMetadata.java
+++ b/src/main/java/codesquad/bows/project/dto/ServiceMetadata.java
@@ -1,18 +1,21 @@
 package codesquad.bows.project.dto;
 
+import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServicePort;
 
 import java.util.List;
 
-public record ServiceMetadata(
+public record ServicePodMetadata(
         String serviceName,
         List<String> externalIps,
         List<Integer> ports,
-        String age
+        String age,
+        String imageName,
+        String
 ) {
 
-    public static ServiceMetadata of(V1Service service) {
+    public static ServicePodMetadata of(V1Service service, V1ContainerStatus containerStatus) {
 
         String name = service.getMetadata().getName();
         List<String> externalIPs = service.getSpec().getExternalIPs();
@@ -22,6 +25,6 @@ public record ServiceMetadata(
                 .toList();
         String creationTimestamp = service.getMetadata().getCreationTimestamp().toString();
 
-        return new ServiceMetadata(name, externalIPs, ports, creationTimestamp);
+        return new ServicePodMetadata(name, externalIPs, ports, creationTimestamp);
     }
 }

--- a/src/main/java/codesquad/bows/project/dto/ServiceState.java
+++ b/src/main/java/codesquad/bows/project/dto/ServiceState.java
@@ -1,0 +1,37 @@
+package codesquad.bows.project.dto;
+
+import io.kubernetes.client.openapi.models.V1ContainerState;
+import io.kubernetes.client.openapi.models.V1ContainerStatus;
+
+public record ServiceState(
+        String imageName,
+        String state,
+        String reason,
+        String message
+) {
+    public static ServiceState from(V1ContainerStatus status) {
+        String state = getState(status.getState());
+        String reason = getReason(status.getState());
+        String message = getMessage(status.getState());
+        return new ServiceState(status.getImage(), state, reason, message);
+    }
+
+    private static String getState(V1ContainerState state) {
+        if (state.getRunning() != null) return "Running";
+        if (state.getWaiting() != null) return "Waiting";
+        if (state.getTerminated() != null) return "Terminated";
+        return "Unknown";
+    }
+
+    private static String getReason(V1ContainerState state) {
+        if (state.getWaiting() != null) return state.getWaiting().getReason();
+        if (state.getTerminated() != null) return state.getTerminated().getReason();
+        return "";
+    }
+
+    private static String getMessage(V1ContainerState state) {
+        if (state.getWaiting() != null) return state.getWaiting().getMessage();
+        if (state.getTerminated() != null) return state.getTerminated().getMessage();
+        return "";
+    }
+}


### PR DESCRIPTION
- pod를 조회하는 것이 아닌 서비스의 '상태'를 조회하는 기능을 추가
  - 애플리케이션 사용자는 k8s를 잘 모르는 유저. 따라서 pod와 svc 등이 무엇인지, 어떤 기능이 있는지를 알 가능성이 낮음
  - BoWS내 기본 배포 단위는 '프로젝트', 그리고 그 프로젝트 내에는 프론트 서비스, 백엔드 서비스 등 '서비스' 단위로 이루어짐
  - 사용자가 가장 궁금한 것은 파드가 어떤 상태이다가 아님. 궁금한 것은 내 서비스가 잘 돌아가는 상태인지, 돌아가지 않는다면 어떤 상태이고 왜인지
  - 따라서 pod의 정보를 조회하는 것보다는 가장 궁금해할만한 pod 내 container status를 뽑아 보여주는 것으로 지표 결정
  - 이를 '서비스의 데이터'내에 포함시켜 k8s를 잘 모르더라도 상태에 대해 직관적으로 알 수 있도록 추상화

close #15 