### PR TITLE
예외처리 로직 추가

### DIFF
--- a/src/main/java/codesquad/bows/global/exception/ExceptionType.java
+++ b/src/main/java/codesquad/bows/global/exception/ExceptionType.java
@@ -10,6 +10,7 @@ public enum ExceptionType {
     PROJECT_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "프로젝트 생성에 실패했습니다"),
     PROJECT_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "프로젝트 삭제에 실패했습니다"),
     DUPLICATED_DOMAIN(HttpStatus.BAD_REQUEST, 5003, "이미 사용중인 도메인은 입력 불가합니다"),
+    PROJECT_NOT_EXIST(HttpStatus.BAD_REQUEST, 5004, "존재하지 않는 프로젝트에 대한 접근입니다"),
 
     // Kubernetes Client
     KUBECTL_EXECUTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5101, "쿠버네티스 제어 중 에러가 발생했습니다");

--- a/src/main/java/codesquad/bows/global/exception/ExceptionType.java
+++ b/src/main/java/codesquad/bows/global/exception/ExceptionType.java
@@ -9,6 +9,7 @@ public enum ExceptionType {
     // PROJECT CRUD
     PROJECT_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "프로젝트 생성에 실패했습니다"),
     PROJECT_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "프로젝트 삭제에 실패했습니다"),
+    DUPLICATED_DOMAIN(HttpStatus.BAD_REQUEST, 5003, "이미 사용중인 도메인은 입력 불가합니다"),
 
     // Kubernetes Client
     KUBECTL_EXECUTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5101, "쿠버네티스 제어 중 에러가 발생했습니다");

--- a/src/main/java/codesquad/bows/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/codesquad/bows/project/dto/ProjectCreateRequest.java
@@ -10,7 +10,7 @@ public record ProjectCreateRequest(
 
         @NotBlank
         @Pattern(regexp = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-        message = "영문 소문자와 숫자, 특수문자로만 이루어져야 합니다(특수문자로 시작하거나 끝나선 안 됩니다)")
+        message = "영문 소문자와 숫자, 특수문자(- . _만 가능)로만 이루어져야 합니다(특수문자로 시작하거나 끝나선 안 됩니다)")
         @Size(max = 30)
         String projectName,
 

--- a/src/main/java/codesquad/bows/project/exception/DuplicatedDomainException.java
+++ b/src/main/java/codesquad/bows/project/exception/DuplicatedDomainException.java
@@ -1,0 +1,11 @@
+package codesquad.bows.project.exception;
+
+import codesquad.bows.global.exception.BusinessException;
+import codesquad.bows.global.exception.ExceptionType;
+
+public class DuplicatedDomainException extends BusinessException {
+
+    public DuplicatedDomainException(){
+        super(ExceptionType.DUPLICATED_DOMAIN);
+    }
+}

--- a/src/main/java/codesquad/bows/project/exception/ProjectNotExistsException.java
+++ b/src/main/java/codesquad/bows/project/exception/ProjectNotExistsException.java
@@ -1,0 +1,10 @@
+package codesquad.bows.project.exception;
+
+import codesquad.bows.global.exception.BusinessException;
+import codesquad.bows.global.exception.ExceptionType;
+
+public class ProjectNotExistsException extends BusinessException {
+    public ProjectNotExistsException(){
+        super(ExceptionType.PROJECT_NOT_EXIST);
+    }
+}

--- a/src/main/java/codesquad/bows/project/repository/ProjectRepository.java
+++ b/src/main/java/codesquad/bows/project/repository/ProjectRepository.java
@@ -22,4 +22,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
            FROM Project p
            """)
     List<ProjectMetadata> findAllProjectMetadata();
+
+    boolean existsByDomain(String domain);
 }

--- a/src/main/java/codesquad/bows/project/service/KubeExecutor.java
+++ b/src/main/java/codesquad/bows/project/service/KubeExecutor.java
@@ -60,7 +60,7 @@ public class KubeExecutor {
                     .map(service -> ServiceMetadata.of(service, getServiceStateFrom(service)))
                     .toList();
 
-        } catch (ApiException e) {
+        } catch (ApiException | NullPointerException e) {
             log.error(e.getMessage());
 
             throw new KubeException();
@@ -79,7 +79,7 @@ public class KubeExecutor {
 
             return ServiceState.from(pod.getStatus().getContainerStatuses().get(0));
 
-        } catch (ApiException e) {
+        } catch (ApiException | NullPointerException e) {
             log.error(e.getMessage());
 
             throw new KubeException();
@@ -87,9 +87,14 @@ public class KubeExecutor {
     }
 
     private String getLabelSelector(V1Service service) {
+        try{
+            return service.getSpec().getSelector().entrySet().stream()
+                    .map(entry -> entry.getKey() + "=" + entry.getValue())
+                    .collect(Collectors.joining(","));
+        } catch (NullPointerException e) {
+            log.error(e.getMessage());
 
-        return service.getSpec().getSelector().entrySet().stream()
-                .map(entry -> entry.getKey() + "=" + entry.getValue())
-                .collect(Collectors.joining(","));
+            throw new KubeException();
+        }
     }
 }

--- a/src/main/java/codesquad/bows/project/service/KubeExecutor.java
+++ b/src/main/java/codesquad/bows/project/service/KubeExecutor.java
@@ -33,6 +33,7 @@ public class KubeExecutor {
     private final CoreV1Api coreV1Api;
 
 
+    // ProjectId를 Release 이름으로 설정하여 Helm 배포 커맨드 생성
     public void createProjectInCluster(Project project){
         Map<String, String> projectOptions = project.getProjectOptions();
         String arguments = projectOptions.entrySet().stream()

--- a/src/main/java/codesquad/bows/project/service/ProjectService.java
+++ b/src/main/java/codesquad/bows/project/service/ProjectService.java
@@ -4,6 +4,7 @@ import codesquad.bows.project.dto.ProjectDetailResponse;
 import codesquad.bows.project.dto.ProjectMetadata;
 import codesquad.bows.project.dto.ServiceMetadata;
 import codesquad.bows.project.exception.DuplicatedDomainException;
+import codesquad.bows.project.exception.ProjectNotExistsException;
 import codesquad.bows.project.repository.ProjectRepository;
 
 import codesquad.bows.project.entity.Project;
@@ -22,6 +23,9 @@ public class ProjectService {
 
     @Transactional(readOnly = true)
     public ProjectDetailResponse getProjectDetail(Long projectId) {
+        if (!projectRepository.existsById(projectId)){
+            throw new ProjectNotExistsException();
+        }
         ProjectMetadata projectMetadata = projectRepository.getMetadataById(projectId);
         List<ServiceMetadata> serviceMetadataList = kubeExecutor.getServiceMetadataOf(projectMetadata.projectName());
         return ProjectDetailResponse.of(projectMetadata, serviceMetadataList);
@@ -29,6 +33,9 @@ public class ProjectService {
 
     @Transactional
     public void deleteProject(Long projectId) {
+        if (!projectRepository.existsById(projectId)){
+            throw new ProjectNotExistsException();
+        }
         projectRepository.deleteById(projectId);
         kubeExecutor.deleteProjectInCluster(projectId);
     }

--- a/src/main/java/codesquad/bows/project/service/ProjectService.java
+++ b/src/main/java/codesquad/bows/project/service/ProjectService.java
@@ -3,6 +3,7 @@ package codesquad.bows.project.service;
 import codesquad.bows.project.dto.ProjectDetailResponse;
 import codesquad.bows.project.dto.ProjectMetadata;
 import codesquad.bows.project.dto.ServiceMetadata;
+import codesquad.bows.project.exception.DuplicatedDomainException;
 import codesquad.bows.project.repository.ProjectRepository;
 
 import codesquad.bows.project.entity.Project;
@@ -38,6 +39,9 @@ public class ProjectService {
 
     @Transactional
     public Long addProject(Project project) {
+        if (projectRepository.existsByDomain(project.getDomain())) {
+            throw new DuplicatedDomainException();
+        }
         Project savedProject = projectRepository.save(project);
         kubeExecutor.createProjectInCluster(savedProject);
         return savedProject.getId();


### PR DESCRIPTION
- kubeExcutor에서 발생하는 npe 안전하게 처리 ( close #20 )
- 프로젝트 이름이 아닌 id로 리소스 이름 생성하도록 변경 ( close #18 )
- 같은 도메인을 사용할 경우 에러 반환하는 로직 추가 ( close #24 )
- 존재하지 않는 projectId 접근 에러 반환 로직 추가